### PR TITLE
Versions must contain only numbers and periods.

### DIFF
--- a/jdee-live/jdee-live.el
+++ b/jdee-live/jdee-live.el
@@ -1,10 +1,15 @@
 ;;; jdee-live.el --- The JVM backend for JDE. -*- lexical-binding: t -*-
 
-;; Version: 0.1-SNAPSHOT
-;; Package-Requires: ((cider)(load-relative))
+;; Version: 0.1
+;; Package-Requires: ((cider "20151020.646")(load-relative "20150224.1722"))
 
+;;; Commentary:
+;;  Prototype nrepl backend
+
+
+;;; Code:
 ;; The contents of this file are subject to the GPL License, Version 3.0.
-(require 'nrepl-client)
+(require 'cider-client)
 (require 'cider)
 (require 'load-relative)
 
@@ -23,8 +28,8 @@
   ;; start a maven process which, connect to the nrepl client, check the
   ;; versions of the middle ware
   (let* ((project-dir
-          (jdee-live-project-directory-for (nrepl-current-dir))))
-    (-when-let (repl-buff (nrepl-find-reusable-repl-buffer nil project-dir))
+          (jdee-live-project-directory-for (cider-current-dir))))
+    (-when-let (repl-buff (cider-find-reusable-repl-buffer nil project-dir))
       (let* ((nrepl-create-client-buffer-function #'cider-repl-create)
              (nrepl-use-this-as-repl-buffer repl-buff)
              (serv-proc

--- a/jdee-maven-nrepl/pom.xml
+++ b/jdee-maven-nrepl/pom.xml
@@ -41,7 +41,7 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.4</version>
         <configuration>
-          <goalPrefix>jdee-maven-nrepl</goalPrefix>
+          <goalPrefix>jdeenrepl</goalPrefix>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>
         <executions>
@@ -53,6 +53,17 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
Required-Packages must have a version.
Force compiler to use 1.5 source

I was unable to get the code to compile as it was, due to several issues.  
- Cask requires a version in Packag-Requires header
- Cask requires that the version is a number, followed by numbers and dots.  The -SNAPSHOT is not allowed.
- Some of the nrepl-\* function have been renamed to cider-*.  Some have aliases and are marked as obsolete, but others are just missing.
- I fixed a warning about the expected name of the plugin not matching the expected value.
- The compiler was treating it as 1.3 source, so I added a plugin setting to treat it as 1.5, the minimum for annotations.
